### PR TITLE
INFRA-58 – remove nickname, which stopped `LogFormat` just becoming the default

### DIFF
--- a/apache/slim.conf
+++ b/apache/slim.conf
@@ -17,7 +17,7 @@
 
     # https://aws.amazon.com/premiumsupport/knowledge-center/trace-elb-x-amzn-trace-id/
     # https://www.ducea.com/2008/02/06/apache-logs-how-long-does-it-take-to-serve-a-request/
-    LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-Agent}i\" \"%{X-Amzn-Trace-Id}i\" **%T/%D**" combined
+    LogFormat "%{X-Forwarded-For}i %h %l %u %t \"%r\" %>s %b %D \"%{Referer}i\" \"%{User-Agent}i\" \"%{X-Amzn-Trace-Id}i\" **%T/%D**"
 
     <Directory /var/www/html/public>
         AllowOverride None


### PR DESCRIPTION
From the docs: "A LogFormat directive that defines a nickname does nothing else -- that is, it only defines the nickname, it doesn't actually apply the format and make it the default."