### PR TITLE
Pin Composer to an older version for now

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,13 @@ COPY apache/slim.conf /etc/apache2/sites-available/
 COPY php/php.ini /usr/local/etc/php/
 
 # Composer
-RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
+# Pin to 2.4.1 for now because 2.4.2 introduced a permissions regression (or tightening) that
+# doesn't work with our built-as-root(?) images, without per-app changes everywhere that
+# Composer is used (e.g. multiple times in every entrypoint). This temporary pin seems like a
+# reasonable step for now because it sounds like Composer are open to improving the behaviour
+# here and there is active discussion this week (23/9/22).
+# https://github.com/composer/composer/issues/11073
+RUN curl -sS https://getcomposer.org/installer | php -- --version=2.4.1 --install-dir=/usr/local/bin --filename=composer
 
 RUN a2enmod rewrite \
  && a2enmod remoteip \


### PR DESCRIPTION
Recent changes have broken Docker builds' use of Composer at runtime, meaning for example MatchBot web's entrypoint never completes

https://github.com/composer/composer/issues/11073