### PR TITLE
BG2-3023: Don't attempt to install Opcache in PHP 8.5

### DIFF
--- a/php8.5/Dockerfile
+++ b/php8.5/Dockerfile
@@ -5,7 +5,6 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/* /var/cache/apk/*
 
 RUN docker-php-ext-install bcmath intl pcntl pdo_mysql zip
-RUN docker-php-ext-enable opcache
 
 RUN pecl install redis && rm -rf /tmp/pear && docker-php-ext-enable redis
 


### PR DESCRIPTION
Opcache is now built in to PHP so doesn't need to be (and cannot be) installed or enabled as a module